### PR TITLE
Fix outdated version of `nodejs` in CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
+        with:
+          node-version: '16'
       - name: Check markdown files using `markdownlint`
         run: |
           npm install -g markdownlint-cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 ### Fixes
 
 * Fix endless loop if commit contains non-existing bug number
+* Fix outdated version of `nodejs` in CI checks
 
 ## 0.1.3 (2019-02-20)
 


### PR DESCRIPTION
Without latest version `markdown-cli` is failed